### PR TITLE
Resolved centering of menu item modal

### DIFF
--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -16,9 +16,9 @@
             <button @click="countAdd()" class="p-2 rounded-full bg-green-500 text-white hover:bg-green-600">+</button>
           </div>
           <!-- Right button -->
-          <button @click="addToCart(item)"   class="flex items-center justify-between p-2 w-36 lg:w-48 rounded-full bg-gray-500 text-white hover:bg-gray-600">
-              <div class="pl-3"> Add to Cart </div>
-              <div class="pr-3">${{ count * item.price }}</div>
+          <button @click="addToCart(item)"   class="flex items-center justify-around p-2 w-36 lg:w-48 rounded-full bg-gray-500 text-white hover:bg-gray-600">
+              <div class=""> Add to Cart </div>
+              <div class="">${{ count * item.price }}</div>
           </button>
         </div>
 

--- a/src/components/PopupWindow.vue
+++ b/src/components/PopupWindow.vue
@@ -3,7 +3,7 @@
     <div v-if="isOpen" class="flex items-center justify-center fixed top-0 right-0 bottom-0 left-0">
       <div id="windowBackground" class="bg-gray-800 bg-opacity-25 absolute top-0 right-0 bottom-0 left-0" @click="closePopupOnOutsideClick"></div> <!-- Background overlay -->
 
-      <div class="max-w-sm sm:max-w-lg lg:max-w-2xl w-full md:w-3/4 lg:w-2/3 xl:w-1/3 bg-white shadow-lg rounded-lg transform translate-x-full md:translate-x-0 absolute top-1/3 left-1/2 xl:custom-left-three-fifths transform -translate-x-1/2 -translate-y-1/2">
+      <div class="max-w-sm sm:max-w-lg lg:max-w-2xl w-full md:w-3/4 lg:w-2/3 xl:w-1/3 bg-white shadow-lg rounded-lg transform translate-x--1/2 left-1/2">
         <!-- Close button -->
         <button @click="closePopup" class="z-[1001] absolute top-0 right-0 p-2 m-2 text-gray-600 hover:text-gray-800 bg-white rounded-full shadow-md">
           <svg class="w-6 h-6 text-gray-600 hover:text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -44,9 +44,6 @@ export default {
 </script>
 
 <style scoped>
-.custom-left-three-fifths{
-  left: 60%;
-}
 .popup-slide-enter-active, .popup-slide-leave-active {
   transition: transform 0.3s ease;
 }


### PR DESCRIPTION
Closes #1 

I went ahead and centered the menu item modal on multiple screen sizes.

There was also a bug where the Add to Cart and Price weren't wrapping properly, I went ahead and resolved this also.

Desktop:
![image](https://github.com/user-attachments/assets/b43688cd-ce75-4f94-bae7-e41eecfc682d)

Tablet:
![image](https://github.com/user-attachments/assets/53f56629-479f-406a-9330-b9ec286a9d7f)

Mobile:
![image](https://github.com/user-attachments/assets/51cb443a-7cf0-43d8-bac9-dde31cb1e194)

**Suggestion:**
Possibly consider making the bg for the modal a bit darker? Might be a bit confusing for those placing the order.