### PR TITLE
add fixed number of decimal places for dollar values

### DIFF
--- a/src/components/Cart.vue
+++ b/src/components/Cart.vue
@@ -81,7 +81,7 @@ export default {
         total += item.price * item.count;
       });
 
-      return total
+      return total.toFixed(2)
     }
   }
 };

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -18,7 +18,7 @@
           <!-- Right button -->
           <button @click="addToCart(item)"   class="flex items-center justify-around p-2 w-36 lg:w-48 rounded-full bg-gray-500 text-white hover:bg-gray-600">
               <div class=""> Add to Cart </div>
-              <div class="">${{ count * item.price }}</div>
+              <div class="">${{ (count * item.price).toFixed(2) }}</div>
           </button>
         </div>
 
@@ -36,7 +36,7 @@
           </div>
           <div class="line"></div>
           <div class="text-menuCard text-left text-lg pt-8 pb-2">
-              ${{ item.price }}
+              ${{ item.price.toFixed(2) }}
           </div >
       </div>
     </button>


### PR DESCRIPTION
There are places around the page where we want to denote dollar values but we dont show the two decimal places: 
![image](https://github.com/user-attachments/assets/f484209d-dafb-4d23-bc4a-1dd3e9b443ea)

![image](https://github.com/user-attachments/assets/35acbd35-4f37-4c3f-bb97-bf7654bade38)

![image](https://github.com/user-attachments/assets/f51d5770-3597-448f-8022-35b201ae8674)


This PR fixes that: 

![image](https://github.com/user-attachments/assets/69dd61bc-f402-4ca4-9330-9a7327a3115f)

![image](https://github.com/user-attachments/assets/16453112-856a-4eda-8e57-b4353d0ec383)
